### PR TITLE
Fixed wierd converCurrencyCode bug.

### DIFF
--- a/DeltaDNA/DDNAProduct.m
+++ b/DeltaDNA/DDNAProduct.m
@@ -123,7 +123,9 @@ static dispatch_once_t onceToken;
     
     NSNumber *minorUnits = [ISO4217 objectForKey:code];
     if (minorUnits) {
-        return [[value decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithMantissa:pow(10, [minorUnits intValue]) exponent:0 isNegative:NO]] integerValue];
+        NSDecimalNumber *number = [NSDecimalNumber decimalNumberWithMantissa:pow(10, [minorUnits intValue]) exponent:0 isNegative:NO];
+        value = [value decimalNumberByMultiplyingBy:number];
+        return (NSInteger)roundf([value floatValue]);
     } else {
         DDNALogWarn(@"Failed to find currency for %@", code);
         return 0;


### PR DESCRIPTION
Hello,
We experienced a weird in DDNAPriduct::convertCurrencyCode method on iOS 10.3.3 (might also affect some other iOS versions) 
It sometimes returns negative value. (EX: code='EUR' value='1.09', or value='1.102')
Seems to be some magic problem in converting NSDecimalNumber to integer value. 
This commit fixes it for us :)

Details on screenshot below
![deltadna_problem](https://user-images.githubusercontent.com/10173114/42100123-a9c79e48-7bbf-11e8-9b04-433a53079985.png)
